### PR TITLE
config: Set Tmux to Use Xclip for Copying on Linux

### DIFF
--- a/tmux.conf
+++ b/tmux.conf
@@ -55,6 +55,7 @@ bind-key -T copy-mode-vi 'v' send-keys -X begin-selection
 # Use y to copy selected text in copy mode (like vim)
 # Copy to Windows clipboard
 if -b 'command -v clip.exe > /dev/null 2>&1' 'bind-key -T copy-mode-vi y send-keys -X copy-pipe-and-cancel "clip.exe"'
+if -b 'command -v xclip > /dev/null 2>&1' 'bind-key -T copy-mode-vi y send-keys -X copy-pipe-and-cancel "xclip -selection clipboard"'
 
 # Select and copy with mouse
 # Note that mouse support is not yet working in the Microsoft Terminal


### PR DESCRIPTION
- On WSL, Tmux is configured to use clip.exe
- If Xclip is installed on the system, which is the case for my linux
  only systems, then use that for tmux copying instead