### PR TITLE
feat: Add Aliases and Functions for Cloud-Dev-Envs

### DIFF
--- a/aliases
+++ b/aliases
@@ -4,6 +4,8 @@ alias ls='ls --color=always'
 alias reload="source $HOME/.zshrc"
 alias fdiff='diff --suppress-common-lines --minimal --side-by-side --ignore-all-space --color=always'
 alias ssha='eval $(ssh-agent -s) && ssh-add'
+alias sshdev='ssh cronquin@cronquin-dev-env.security.nonprod.bxt.com'
+alias rcode='ssh -tt -q -L 127.0.0.1:8080:localhost:8080 cronquin@cronquin-dev-env.security.nonprod.bxt.com code-server --auth none --disable-updates'
 
 # Package Manager
 alias apt-remove='sudo apt-get purge'

--- a/bin/ssht
+++ b/bin/ssht
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+
+# ssh tunnel
+
+ssht() {
+  local port=$1
+
+  ssh -tt -q -L 127.0.0.1:${port}:localhost:${port} cronquin@cronquin-dev-env.security.nonprod.bxt.com
+}
+
+ssht $@


### PR DESCRIPTION
- Adds aliases and functions for working with the cloud-dev-environments
  to allow for quickly sshing to my cloud dev environment and for
  exposing ports to be used by code-server or other services that are
  spun up on the remote development server